### PR TITLE
remove duplicate top level items

### DIFF
--- a/h-card/nested/output.json
+++ b/h-card/nested/output.json
@@ -12,16 +12,5 @@
                 "url": ["http://mozilla.org/"]
             }
         }]
-    },{
-        "type": ["h-card"],
-        "properties": {
-            "name": ["Mozilla Foundation"],
-            "url": ["http://mozilla.org/"]
-        }
-    },{
-        "type": ["h-org"],
-        "properties": {
-            "name": ["Mozilla Foundation"]
-        }
     }]
 }


### PR DESCRIPTION
remove duplicate top level items. the h-card and h-org only show up as the one entry in children. E.g. see 4th example here: http://microformats.org/wiki/microformats2#h-card_org_h-card (that has ```<a class="h-org h-card" ...``` in it). cc @andyleap.